### PR TITLE
Error: No such sub-command 'trend'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
 gemspec
 
 group :test do
-  gem 'rake', '~> 10.1.0'
-  gem 'minitest'
+  gem 'rake', '~> 13.0'
+  gem 'minitest', '5.18'
   gem 'minitest-spec-context'
   gem 'simplecov'
   gem 'mocha'

--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,5 @@ Rake::TestTask.new do |t|
   t.libs.push "lib"
   t.test_files = Dir.glob('test/**/*_test.rb')
   t.verbose = true
+  t.warning = ENV.key?('RUBY_WARNINGS')
 end

--- a/test/trend_test.rb
+++ b/test/trend_test.rb
@@ -16,7 +16,7 @@ describe 'trend' do
     it 'should return a list of trends' do
       api_expects(:trends, :index, 'List trends').returns(@trends)
       result = run_cmd(@cmd)
-      result.exit_code.must_equal HammerCLI::EX_OK
+      _(result.exit_code).must_equal HammerCLI::EX_OK
     end
   end
 
@@ -36,7 +36,7 @@ describe 'trend' do
       api_expects(:trends, :show, 'Show trend').returns(@trend)
 
       result = run_cmd(@cmd + params)
-      result.exit_code.must_equal HammerCLI::EX_OK
+      _(result.exit_code).must_equal HammerCLI::EX_OK
     end
   end
 
@@ -50,7 +50,7 @@ describe 'trend' do
 
       api_expects_no_call
       result = run_cmd(@cmd)
-      assert_match(expected_result, result.err)
+      _(result.err).must_match(expected_result)
     end
 
     it 'should create a trend' do


### PR DESCRIPTION
### Issue:

I started facing failure while running it against ruby v3+, I tried updating gem version and looked in deprecated syntax while changing the gem version. but it didn't worked! It is complaining about `trend` command.

<details>
  <summary>hammer-cli-foreman-statistics: failure</summary>
  
  ```
 
# Running:

FFFFF

Finished in 0.011745s, 425.7286 runs/s, 510.8743 assertions/s.

  1) Failure:
trend::delete#test_0001_should delete a trend [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-statistics/test/trend_test.rb:80]:
--- expected
+++ actual
@@ -1 +1,4 @@
-""
+"Error: No such sub-command 'trend'.
+
+See: 'hammer --help'.
+"


  2) Failure:
trend::create#test_0002_should create a trend [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-statistics/test/trend_test.rb:65]:
--- expected
+++ actual
@@ -1 +1,4 @@
-""
+"Error: No such sub-command 'trend'.
+
+See: 'hammer --help'.
+"


  3) Failure:
trend::create#test_0001_should print error on missing --trendable-type [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-statistics/test/trend_test.rb:53]:
Expected /Could\ not\ create\ the\ trend:\n\ \ Missing\ arguments\ for\ '\-\-trendable\-type'\.\n/ to match "Error: No such sub-command 'trend'.\n\nSee: 'hammer --help'.\n".

  4) Failure:
trend::info#test_0001_should return a trend [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-statistics/test/trend_test.rb:39]:
Expected: 0
  Actual: 64

  5) Failure:
trend::list#test_0001_should return a list of trends [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-statistics/test/trend_test.rb:19]:
Expected: 0
  Actual: 64

5 runs, 6 assertions, 5 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /home/akumari/Desktop/theforeman_hammer_cli/coverage. 1702 / 3691 LOC (46.11%) covered.
rake aborted!
Command failed with status (1): [ruby -I"lib:lib" /home/akumari/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/trend_test.rb" ]
/home/akumari/.rbenv/versions/3.1.2/bin/bundle:25:in `load'
/home/akumari/.rbenv/versions/3.1.2/bin/bundle:25:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)

```
  
</details>


### Configuration
Ruby version: 3.1.2
rbenv version: 1.2.0